### PR TITLE
Remap GClass2040 to NotificationLocalization

### DIFF
--- a/SIT.Launcher/DeObfus/mappings/SIT/SITRemapperConfig.json
+++ b/SIT.Launcher/DeObfus/mappings/SIT/SITRemapperConfig.json
@@ -96,6 +96,11 @@
       "HasFields": [],
       "HasMethodsStatic": [ "LoadApplicationConfig" ]
     },
+    {
+      "RenameClassNameTo": "NotificationLocalization",
+      "IsClass": true,
+      "HasFields": [ "localizationKey_0", "localizationKey_1", "int_0" ]
+    },
 
 
     // -----------------------------------------


### PR DESCRIPTION
**UNTESTED BECAUSE I'M VS2019, IT CAN'T INSTALL .NET 7.0**

Remap "GClass2040" from 0.14.1.1.28965 to "NotificationLocalization" (maybe give it a better name?)